### PR TITLE
Use organization secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
         uses: peaceiris/actions-gh-pages@bbdfb200618d235585ad98e965f4aafc39b4c501
         with:
           # personal token can be generated at https://github.com/settings/tokens,
-          # and added to "Settings"->"Secrets"
-          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          # and added to https://github.com/organizations/seismo-learn/settings/secrets/actions
+          personal_token: ${{ secrets.TOKEN_DOCUMENT_DEPLOY }}
           external_repository: seismo-learn/seismo-learn.github.io
           publish_branch: main
           publish_dir: ./public


### PR DESCRIPTION
FYI, I added an organization secret `TOKEN_DOCUMENT_DEPLOY`
to https://github.com/seismo-learn/website/settings/secrets/actions.

The token can be used by any repositories in the organization,
so that we don't have to generate tokens for every repository.
