### PR TITLE
No need to generate the .nojekyll file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ all: build
 
 build:
 	hugo
-	touch public/.nojekyll
 	echo seismo-learn.org > public/CNAME
 
 server:


### PR DESCRIPTION
The [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages)
action adds an empty `.nojekyll` file by default
(https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-enable-built-in-jekyll-enable_jekyll).

So we don't have to do it.
