### PR TITLE
Update the check-link workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -32,8 +32,7 @@ jobs:
         # 429: Too many requests
         args: >
           --accept 429
-          --exclude "^https://seismo-learn.org/images/icon_hu87f995c79e6e1fece146ad5362c6d8c3_53652_192x192_fill_lanczos_center_2.png/$"
-          --exclude "http://localhost:1313/"
+          --exclude "http://localhost"
           --exclude "https://fonts.gstatic.com/"
           --verbose
           "repository/README.md"
@@ -43,6 +42,7 @@ jobs:
 
     - name: Create Issue From File
       uses: peter-evans/create-issue-from-file@v3
+      if: github.event_name != 'pull_request'
       with:
         title: Link Checker Report
         content-filepath: ./lychee/out.md


### PR DESCRIPTION
Changes in this PR:

1. Recent lychee releases have fixed a bug so we can remove one excluded URL
2. Change `http://localhost:1313/` to `http://localhost` so all URLs starting with localhost will be skipped
3. When we enable the workflow in PRs, each commit will trigger the workflow. If links are broken, each commit will create an issue report. For example, this PR https://github.com/seismo-learn/links/pull/131 creates multiple issues and they're really annoying. So I decide to disable "issue report" for PRs. You can still view the workflow status on the "Actions" page.