### PR TITLE
Update the workflow to check links of all sites

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ name: Check Links
 
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  pull_request:
+  # pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,7 +3,7 @@ name: Check Links
 
 on:
   # Uncomment the 'pull_request' line below to trigger the workflow in PR
-  # pull_request:
+  pull_request:
   # Schedule runs on 12 noon every Sunday
   schedule:
     - cron: '0 12 * * 0'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,8 +18,8 @@ jobs:
       run: |
         for repo in contributing links seismology seismology101 software website; do
           echo $repo
+          git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
         done
-        #  git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
         #done
         #for repo in contributing links seismology seismology101 software; do
         #  git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,14 +17,12 @@ jobs:
     - name: Check out the repositories and sites
       run: |
         for repo in contributing links seismology seismology101 software website; do
-          echo $repo
           git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
         done
-        #done
-        #for repo in contributing links seismology seismology101 software; do
-        #  git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site
-        #done
-        #git clone --depth 1 --branch main https://github.com/seismo-learn/seismo-learn.github.io seismo-learn/website/site
+        for repo in contributing links seismology seismology101 software; do
+          git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site
+        done
+        git clone --depth 1 --branch main https://github.com/seismo-learn/seismo-learn.github.io seismo-learn/website/site
 
     - name: Link Checker
       uses: lycheeverse/lychee-action@v1.0.8

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,8 +16,9 @@ jobs:
     steps:
     - name: Check out the repositories and sites
       run: |
-        echo A
-        #for repo in contributing links seismology seismology101 software website; do
+        for repo in contributing links seismology seismology101 software website; do
+          echo $repo
+        done
         #  git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
         #done
         #for repo in contributing links seismology seismology101 software; do

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,20 +12,18 @@ jobs:
   check_links:
     name: Check Links
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
 
     steps:
     - name: Check out the repositories and sites
       run: |
-        for repo in contributing links seismology seismology101 software website; do
-	      git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
-        done
-        for repo in contributing links seismology seismology101 software; do
-	      git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site
-        done
-        git clone --depth 1 --branch main https://github.com/seismo-learn/seismo-learn.github.io seismo-learn/website/site
+        echo A
+        #for repo in contributing links seismology seismology101 software website; do
+        #  git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
+        #done
+        #for repo in contributing links seismology seismology101 software; do
+        #  git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site
+        #done
+        #git clone --depth 1 --branch main https://github.com/seismo-learn/seismo-learn.github.io seismo-learn/website/site
 
     - name: Link Checker
       uses: lycheeverse/lychee-action@v1.0.8

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -30,6 +30,7 @@ jobs:
         # 429: Too many requests
         args: >
           --accept 429
+          --exclude-all-private
           --verbose
           "seismo-learn/*/repo/README.md"
           "seismo-learn/*/site/**/*.html"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,14 +17,16 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2.3.4
       with:
-        path: repository
+        repository: seismo-learn/website
+        ref: main
+        path: seismo-learn/website/repo
 
     - name: Checkout the website
       uses: actions/checkout@v2.3.4
       with:
         repository: seismo-learn/seismo-learn.github.io
         ref: main
-        path: website
+        path: seismo-learn/website/site
 
     - name: Link Checker
       uses: lycheeverse/lychee-action@v1.0.8
@@ -35,8 +37,8 @@ jobs:
           --exclude "http://localhost"
           --exclude "https://fonts.gstatic.com/"
           --verbose
-          "repository/README.md"
-          "website/**/*.html"
+          "seismo-learn/*/repo/README.md"
+          "seismo-learn/*/site/**/*.html"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # seismo-learn/website
     - name: Check out the repositories and sites
       run: |
         for repo in contributing links seismology seismology101 software website; do

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -14,19 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout the repository
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: seismo-learn/website
-        ref: main
-        path: seismo-learn/website/repo
-
-    - name: Checkout the website
-      uses: actions/checkout@v2.3.4
-      with:
-        repository: seismo-learn/seismo-learn.github.io
-        ref: main
-        path: seismo-learn/website/site
+    # seismo-learn/website
+    - name: Check out the repositories and sites
+      run: |
+        for repo in contributing links seismology seismology101 software website; do
+	      git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
+        done
+        for repo in contributing links seismology seismology101 software; do
+	      git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site
+        done
+        git clone --depth 1 --branch main https://github.com/seismo-learn/seismo-learn.github.io seismo-learn/website/site
 
     - name: Link Checker
       uses: lycheeverse/lychee-action@v1.0.8
@@ -34,8 +31,6 @@ jobs:
         # 429: Too many requests
         args: >
           --accept 429
-          --exclude "http://localhost"
-          --exclude "https://fonts.gstatic.com/"
           --verbose
           "seismo-learn/*/repo/README.md"
           "seismo-learn/*/site/**/*.html"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -12,6 +12,9 @@ jobs:
   check_links:
     name: Check Links
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
     steps:
     - name: Check out the repositories and sites

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Check out the repositories and sites
       run: |
-        for repo in contributing links seismology seismology101 software website; do
+        for repo in contributing seismology seismology101 software website links; do
           git clone --depth 1 --branch main https://github.com/seismo-learn/${repo} seismo-learn/${repo}/repo
         done
-        for repo in contributing links seismology seismology101 software; do
+        for repo in contributing seismology seismology101 software links; do
           git clone --depth 1 --branch gh-pages https://github.com/seismo-learn/${repo} seismo-learn/${repo}/site
         done
         git clone --depth 1 --branch main https://github.com/seismo-learn/seismo-learn.github.io seismo-learn/website/site

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -31,6 +31,13 @@ jobs:
         args: >
           --accept 429
           --exclude-all-private
+          --exclude "http://localhost"
+          --exclude "https://fonts.gstatic.com"
+          --exclude "https://pkgs.org"
+          --exclude "https://www.fdsn.org/xml/station"
+          --exclude "https://www.hinet.bosai.go.jp"
+          --exclude "https://www.fnet.bosai.go.jp"
+          --exclude "https://apt.repos.intel.com/oneapi"
           --verbose
           "seismo-learn/*/repo/README.md"
           "seismo-learn/*/site/**/*.html"


### PR DESCRIPTION
In this PR, the check-links workflow is updated to clone all repos and all sites (including website, contributing, seismology, seismology101, links, and software) and check all the links.

The check-link workflow in other repos will be deleted.

See https://github.com/seismo-learn/website/runs/2714009032?check_suite_focus=true for the latest run of the workflow. 

Closes #56